### PR TITLE
Add retries to rabbitmq_aws module

### DIFF
--- a/deps/rabbitmq_aws/test/src/rabbitmq_aws_tests.erl
+++ b/deps/rabbitmq_aws/test/src/rabbitmq_aws_tests.erl
@@ -479,7 +479,7 @@ api_get_request_test_() ->
           ?assertEqual({error, credentials}, Result)
         end
       },
-      {"AWS service API request failed - API error",
+      {"AWS service API request failed - persistent API error",
         fun() ->
           State = #state{access_key = "ExpiredKey",
                          secret_access_key = "ExpiredAccessKey",
@@ -489,9 +489,27 @@ api_get_request_test_() ->
           {ok, Pid} = rabbitmq_aws:start_link(),
           rabbitmq_aws:set_region("us-east-1"),
           rabbitmq_aws:set_credentials(State),
-          Result = rabbitmq_aws:api_get_request("AWS", "API"),
+          Result = rabbitmq_aws:api_get_request_with_retries("AWS", "API", 3, 1),
           ok = gen_server:stop(Pid),
           ?assertEqual({error, "invalid input"}, Result),
+          meck:validate(httpc)
+        end
+      },
+      {"AWS service API request failed - transient API error",
+        fun() ->
+          State = #state{access_key = "ExpiredKey",
+                         secret_access_key = "ExpiredAccessKey",
+                         region = "us-east-1",
+                         expiration = {{3016, 4, 1}, {12, 0, 0}}},
+          meck:expect(httpc, request, 4, meck:seq(
+            [{error, "internal server error"},
+             {ok, {{"HTTP/1.0", 200, "OK"}, [{"content-type", "application/json"}], "{\"data\": \"value\"}"}}])),
+          {ok, Pid} = rabbitmq_aws:start_link(),
+          rabbitmq_aws:set_region("us-east-1"),
+          rabbitmq_aws:set_credentials(State),
+          Result = rabbitmq_aws:api_get_request_with_retries("AWS", "API", 3, 1),
+          ok = gen_server:stop(Pid),
+          ?assertEqual({ok, [{"data", "value"}]}, Result),
           meck:validate(httpc)
         end
       }


### PR DESCRIPTION
## Proposed Changes
RabbitMQ AWS peer discovery `lock` and `unlock` methods depend on AWS APIs. When API has transient issue, the `unlock` call can fail silently, causing subsequent nodes cannot join the cluster.

This change adds retries to increase resiliency of the AWS client.

Note that this change only reduces the probability of failure for AWS peer discovery plugin, but does not resolve the root cause as rabbit_mnesia:init_with_lock does not fail if rabbit_peer_discovery:unlock fails. Additionally, other peer discovery plugins can also be impacted by this root cause. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories